### PR TITLE
Fix migration that fails on field read.

### DIFF
--- a/config/migrations/2016_01_01_000000_create_notifications_table.php
+++ b/config/migrations/2016_01_01_000000_create_notifications_table.php
@@ -33,7 +33,7 @@ class CreateNotificationsTable extends Migration
             $table->text('text');
             $table->dateTime('date');
             $table->string('user', 255);
-            $table->integer('read', 2);
+            $table->boolean('read')->default(false);
         });
     }
 


### PR DESCRIPTION
Changed the type of field read from integer to boolean and assign a default value of 'false'.
